### PR TITLE
Chillin player orbit 1

### DIFF
--- a/new year jam/project.godot
+++ b/new year jam/project.godot
@@ -31,8 +31,8 @@ general/balloon_path="res://assets/dialogues/dialogue_balloons/balloon.tscn"
 
 window/size/viewport_width=640
 window/size/viewport_height=360
-window/size/window_width_override=1920
-window/size/window_height_override=1080
+window/size/window_width_override=1280
+window/size/window_height_override=720
 window/stretch/mode="canvas_items"
 window/stretch/aspect="keep_width"
 window/stretch/scale_mode="integer"

--- a/new year jam/project.godot
+++ b/new year jam/project.godot
@@ -84,6 +84,14 @@ move_right={
 
 locale/translations_pot_files=PackedStringArray("res://assets/dialogues/test.dialogue")
 
+[layer_names]
+
+2d_physics/layer_1="player"
+2d_physics/layer_2="stars"
+2d_physics/layer_3="star_orbits"
+2d_physics/layer_4="asteroids"
+2d_physics/layer_5="player_orbit_detect"
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0

--- a/new year jam/scenes/components/orbit_box/orbit_box.gd
+++ b/new year jam/scenes/components/orbit_box/orbit_box.gd
@@ -2,8 +2,13 @@ extends Area2D
 
 @export var presets : Array[PackedScene]
 var collision : CollisionShape2D
+var arc_size
 func _ready():
 	collision = get_child(0) #hardcoded bc always only 1 child
 	
 func set_orbit_size(size : int):
 	collision.shape.radius = size
+	arc_size = size
+
+func _draw():
+	draw_arc(Vector2(0, 0), arc_size, 0, TAU, 50, Color(Color.WHITE, 0.2))

--- a/new year jam/scenes/components/orbit_box/orbit_box.gd
+++ b/new year jam/scenes/components/orbit_box/orbit_box.gd
@@ -1,0 +1,9 @@
+extends Area2D
+
+@export var presets : Array[PackedScene]
+var collision : CollisionShape2D
+func _ready():
+	collision = get_child(0) #hardcoded bc always only 1 child
+	
+func set_orbit_size(size : int):
+	collision.shape.radius = size

--- a/new year jam/scenes/components/orbit_box/orbit_box.tscn
+++ b/new year jam/scenes/components/orbit_box/orbit_box.tscn
@@ -1,3 +1,14 @@
-[gd_scene format=3 uid="uid://bhsmngj7x2aco"]
+[gd_scene load_steps=3 format=3 uid="uid://bhsmngj7x2aco"]
+
+[ext_resource type="Script" path="res://scenes/components/orbit_box/orbit_box.gd" id="1_84e6c"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_8evr0"]
+resource_local_to_scene = true
 
 [node name="OrbitBox" type="Area2D"]
+collision_layer = 4
+collision_mask = 16
+script = ExtResource("1_84e6c")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_8evr0")

--- a/new year jam/scenes/components/orbit_detection/orbit_detection.tscn
+++ b/new year jam/scenes/components/orbit_detection/orbit_detection.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3 uid="uid://dt6km7owkblb"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_c4hft"]
+radius = 20.0
+
+[node name="OrbitDetection" type="Area2D"]
+collision_layer = 16
+collision_mask = 4
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_c4hft")

--- a/new year jam/scenes/game_object/player/player.gd
+++ b/new year jam/scenes/game_object/player/player.gd
@@ -1,35 +1,79 @@
 extends CharacterBody2D
 class_name Player
 
+@onready var exit_timer = $OrbitExitTimer
+@export var orbit_manager : OrbitManager
+
 const MAX_SPEED = 200
 const ACCEL_SMOOTHING = 3
 const STAMINA_DRAIN = 0.00075
 
+var movement_allowed = true
+var orbiting_star : Star
+var is_orbiting = false
+var tween
+
 # Custom Signal to emit to stamina manager
 signal player_move(stamina_drain: float)
 
+# custom signal to orbit_manager to control the player's
+# position while in orbit
+signal entered_star_orbit(star : Star)
+
+# custom signal to request exit from star orbit
+# takes no arguments since star should be the last star landed on
+signal exiting_star_orbit
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	exit_timer.timeout.connect(on_exit_timer_timeout)
+	orbit_manager.orbit_exited.connect(on_orbit_exited)
 
-
+func on_exit_timer_timeout():
+	exiting_star_orbit.emit()
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
+	if is_orbiting:
+		if Input.is_action_just_pressed("space"):
+			exit_timer.start()
+		
+		if Input.is_action_just_released("space"):
+			exit_timer.stop()
+	
 	var dir: Vector2 = get_movement_vector()
 	var target_velocity = dir * MAX_SPEED
 	
 	velocity = velocity.lerp(target_velocity, 1 - exp(-delta * ACCEL_SMOOTHING))
+	
 	move_and_slide()
 	
 	# If player input vector is non-zero, emit the player_move signal
 	if(dir != Vector2.ZERO):
 		emit_player_move()
 	
+	
 
 func get_movement_vector(): 
-	var movement_dir: Vector2 = Input.get_vector("move_left", "move_right", "move_up", "move_down")
+	var movement_dir: Vector2 
+	if movement_allowed:
+		movement_dir = Input.get_vector("move_left", "move_right", "move_up", "move_down")
 	return movement_dir
 	
 	
 func emit_player_move():
 	player_move.emit(STAMINA_DRAIN)
+
+
+func _on_orbit_detection_area_entered(area):
+	is_orbiting = true
+	movement_allowed = false
+	
+	orbiting_star = area.get_parent()
+
+	await orbiting_star.star_orbit_entered
+	entered_star_orbit.emit(orbiting_star)
+
+func on_orbit_exited():
+	movement_allowed = true
+	is_orbiting = false
+

--- a/new year jam/scenes/game_object/player/player.gd
+++ b/new year jam/scenes/game_object/player/player.gd
@@ -24,6 +24,8 @@ signal entered_star_orbit(star : Star)
 # takes no arguments since star should be the last star landed on
 signal exiting_star_orbit
 
+signal timer_value() # for the UI
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	exit_timer.timeout.connect(on_exit_timer_timeout)
@@ -35,6 +37,7 @@ func on_exit_timer_timeout():
 func _process(delta):
 	if is_orbiting:
 		if Input.is_action_just_pressed("space"):
+			timer_value.emit()
 			exit_timer.start()
 		
 		if Input.is_action_just_released("space"):

--- a/new year jam/scenes/game_object/player/player.tscn
+++ b/new year jam/scenes/game_object/player/player.tscn
@@ -68,7 +68,7 @@ color_ramp = SubResource("Gradient_u6qy6")
 
 [node name="CPUParticles2D2" type="CPUParticles2D" parent="."]
 show_behind_parent = true
-amount = 10
+amount = 12
 speed_scale = 0.5
 randomness = 1.0
 emission_shape = 1

--- a/new year jam/scenes/game_object/player/player.tscn
+++ b/new year jam/scenes/game_object/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://bp3l8aovtvlcw"]
+[gd_scene load_steps=9 format=3 uid="uid://bp3l8aovtvlcw"]
 
 [ext_resource type="Script" path="res://scenes/game_object/player/player.gd" id="1_m2iwv"]
 [ext_resource type="Texture2D" uid="uid://bhxckgi4kchs6" path="res://assets/player-placeholder-16.png" id="2_ffgov"]
@@ -12,13 +12,23 @@ _data = [Vector2(0, 100), 0.0, 65.2015, 0, 0, Vector2(0.460674, 56.044), 83.8305
 point_count = 3
 
 [sub_resource type="Curve" id="Curve_ghuq4"]
-_data = [Vector2(0.207865, 1), 0.0, 0.529762, 0, 0, Vector2(0.876405, 0.274725), 0.0, 0.0, 0, 0]
+max_value = 1.5
+_data = [Vector2(0, 1.45055), 0.0, -0.0929072, 0, 0, Vector2(0.991936, 0.0989012), 0.0, 0.0, 0, 0]
 point_count = 2
 
 [sub_resource type="Gradient" id="Gradient_u6qy6"]
 interpolation_mode = 2
-offsets = PackedFloat32Array(0.193333, 0.553333, 0.82)
-colors = PackedColorArray(0.968627, 0.937255, 0.780392, 1, 0.831646, 0.602764, 0.544656, 1, 0.8, 0.52549, 0.490196, 1)
+offsets = PackedFloat32Array(0.193333, 0.553333, 0.82, 1)
+colors = PackedColorArray(0.968627, 0.937255, 0.780392, 1, 0.831373, 0.603922, 0.545098, 0.756863, 0.8, 0.52549, 0.490196, 0.466667, 0.8, 0.52549, 0.490196, 0)
+
+[sub_resource type="Curve" id="Curve_p7kfj"]
+_data = [Vector2(0, 1), 0.0, -0.435482, 0, 1, Vector2(1, 0), -3.02808, 0.0, 1, 0]
+point_count = 2
+
+[sub_resource type="Curve" id="Curve_a7dra"]
+max_value = 100.0
+_data = [Vector2(0, 0), 0.0, 240.465, 0, 0, Vector2(1, 100), 0.0, 0.0, 0, 0]
+point_count = 2
 
 [node name="Player" type="CharacterBody2D" groups=["player"]]
 motion_mode = 1
@@ -34,16 +44,39 @@ shape = SubResource("CircleShape2D_sfra7")
 
 [node name="CPUParticles2D" type="CPUParticles2D" parent="."]
 show_behind_parent = true
-amount = 128
+amount = 64
 lifetime = 1.5
-randomness = 0.5
-lifetime_randomness = 0.5
+speed_scale = 2.0
+randomness = 0.45
 emission_shape = 1
 emission_sphere_radius = 1.0
+spread = 90.0
 gravity = Vector2(0, 0)
+tangential_accel_min = 10.0
+tangential_accel_max = 10.0
 damping_max = 16.0
 damping_curve = SubResource("Curve_821y6")
 scale_amount_max = 6.0
+scale_amount_curve = SubResource("Curve_ghuq4")
+color = Color(0.968627, 0.937255, 0.780392, 1)
+color_ramp = SubResource("Gradient_u6qy6")
+
+[node name="CPUParticles2D2" type="CPUParticles2D" parent="."]
+show_behind_parent = true
+amount = 10
+speed_scale = 0.5
+randomness = 1.0
+emission_shape = 1
+emission_sphere_radius = 1.0
+spread = 180.0
+gravity = Vector2(0, 0)
+initial_velocity_min = 50.0
+initial_velocity_max = 100.0
+linear_accel_min = -150.0
+linear_accel_max = -150.0
+linear_accel_curve = SubResource("Curve_p7kfj")
+damping_curve = SubResource("Curve_a7dra")
+scale_amount_max = 2.0
 scale_amount_curve = SubResource("Curve_ghuq4")
 color = Color(0.968627, 0.937255, 0.780392, 1)
 color_ramp = SubResource("Gradient_u6qy6")

--- a/new year jam/scenes/game_object/player/player.tscn
+++ b/new year jam/scenes/game_object/player/player.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=9 format=3 uid="uid://bp3l8aovtvlcw"]
+[gd_scene load_steps=10 format=3 uid="uid://bp3l8aovtvlcw"]
 
 [ext_resource type="Script" path="res://scenes/game_object/player/player.gd" id="1_m2iwv"]
 [ext_resource type="Texture2D" uid="uid://bhxckgi4kchs6" path="res://assets/player-placeholder-16.png" id="2_ffgov"]
+[ext_resource type="PackedScene" uid="uid://dt6km7owkblb" path="res://scenes/components/orbit_detection/orbit_detection.tscn" id="3_jljpd"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_sfra7"]
-radius = 10.2956
+radius = 8.0
 
 [sub_resource type="Curve" id="Curve_821y6"]
 max_value = 100.0
@@ -33,6 +34,10 @@ point_count = 2
 [node name="Player" type="CharacterBody2D" groups=["player"]]
 motion_mode = 1
 script = ExtResource("1_m2iwv")
+
+[node name="OrbitExitTimer" type="Timer" parent="."]
+wait_time = 0.5
+one_shot = true
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(2.08165e-12, 2.08165e-12)
@@ -80,3 +85,7 @@ scale_amount_max = 2.0
 scale_amount_curve = SubResource("Curve_ghuq4")
 color = Color(0.968627, 0.937255, 0.780392, 1)
 color_ramp = SubResource("Gradient_u6qy6")
+
+[node name="OrbitDetection" parent="." instance=ExtResource("3_jljpd")]
+
+[connection signal="area_entered" from="OrbitDetection" to="." method="_on_orbit_detection_area_entered"]

--- a/new year jam/scenes/game_object/star/RotateAnchor.gd
+++ b/new year jam/scenes/game_object/star/RotateAnchor.gd
@@ -1,0 +1,23 @@
+extends Node2D
+@onready var snap_point : Node2D = $SnapPoint
+
+var orbit_started : bool = false
+
+var orbit_speed_mod
+
+var rotation_dir : int = 1 # can either be 1 or -1
+
+func _process(delta):
+	if orbit_started:
+		if get_parent().orbit_size == 90:
+			print("large")
+			rotate(0.1 * rotation_dir * delta)
+		else:
+			rotate(1 * rotation_dir *delta)
+	
+
+func set_orbit_snap_distance(size):
+	snap_point.position = Vector2(size, 0.0)
+
+func snap_point_to_player_on_radius(player):
+	look_at(player.global_position)

--- a/new year jam/scenes/game_object/star/RotateAnchor.gd
+++ b/new year jam/scenes/game_object/star/RotateAnchor.gd
@@ -3,17 +3,16 @@ extends Node2D
 
 var orbit_started : bool = false
 
-var orbit_speed_mod
+var orbit_speed_mod = 1
 
 var rotation_dir : int = 1 # can either be 1 or -1
 
 func _process(delta):
 	if orbit_started:
-		if get_parent().orbit_size == 90:
-			print("large")
-			rotate(0.1 * rotation_dir * delta)
+		if orbit_speed_mod == 90:
+			rotate(0.5* rotation_dir * delta)
 		else:
-			rotate(1 * rotation_dir *delta)
+			rotate(1 * rotation_dir * delta)
 	
 
 func set_orbit_snap_distance(size):

--- a/new year jam/scenes/game_object/star/star.gd
+++ b/new year jam/scenes/game_object/star/star.gd
@@ -17,7 +17,7 @@ func _ready():
 	var size = get_random_size()
 	set_sprite_scale(size)
 	
-	var orbit_size = convert_size_to_int(size)
+	orbit_size = convert_size_to_int(size)
 	
 	orbit_box.set_orbit_size(orbit_size)
 	rotate_anchor.set_orbit_snap_distance(orbit_size)
@@ -58,7 +58,9 @@ func convert_size_to_int(size):
 func on_orbit_entered(area):
 	var body = area.get_parent()
 	rotate_anchor.snap_point_to_player_on_radius(body)
+	rotate_anchor.orbit_speed_mod = orbit_size
 	rotate_anchor.orbit_started = true
+	rotate_anchor.rotation_dir = 1 if area.global_position.x > orbit_point.global_position.x else -1
 	star_orbit_entered.emit(self)
 
 func on_orbit_exited(area):

--- a/new year jam/scenes/game_object/star/star.gd
+++ b/new year jam/scenes/game_object/star/star.gd
@@ -3,6 +3,11 @@ class_name Star
 
 @export var star_size: Array[String] =  ["Small", "Medium", "Large"]
 @onready var sprite: Sprite2D = $Sprite2D
+@onready var orbit_box = $OrbitBox
+@onready var rotate_anchor = $RotateAnchor
+var orbit_point
+
+signal star_orbit_entered(star)
 
 var orbit_size # for the orbit component
 
@@ -10,8 +15,17 @@ var orbit_size # for the orbit component
 func _ready():
 	randomize()
 	var size = get_random_size()
-	orbit_size = size
 	set_sprite_scale(size)
+	
+	var orbit_size = convert_size_to_int(size)
+	
+	orbit_box.set_orbit_size(orbit_size)
+	rotate_anchor.set_orbit_snap_distance(orbit_size)
+	
+	orbit_box.area_entered.connect(on_orbit_entered)
+	orbit_box.area_exited.connect(on_orbit_exited)
+	
+	orbit_point = rotate_anchor.snap_point
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
@@ -31,3 +45,21 @@ func set_sprite_scale(sprite_size: String):
 		"Large":
 			sprite.scale = Vector2(3,3)
 			return
+
+func convert_size_to_int(size):
+	match size:
+		"Small":
+			return 30
+		"Medium":
+			return 45
+		"Large":
+			return 90
+
+func on_orbit_entered(area):
+	var body = area.get_parent()
+	rotate_anchor.snap_point_to_player_on_radius(body)
+	rotate_anchor.orbit_started = true
+	star_orbit_entered.emit(self)
+
+func on_orbit_exited(area):
+	rotate_anchor.orbit_started = false

--- a/new year jam/scenes/game_object/star/star.tscn
+++ b/new year jam/scenes/game_object/star/star.tscn
@@ -1,7 +1,10 @@
-[gd_scene load_steps=4 format=3 uid="uid://df4xityvlxgrr"]
+[gd_scene load_steps=7 format=3 uid="uid://df4xityvlxgrr"]
 
 [ext_resource type="Script" path="res://scenes/game_object/star/star.gd" id="1_f1qur"]
 [ext_resource type="Texture2D" uid="uid://df6e0ekeexwqw" path="res://assets/player-placeholder.png" id="1_fx2rj"]
+[ext_resource type="Script" path="res://scenes/game_object/star/RotateAnchor.gd" id="3_0vatv"]
+[ext_resource type="Texture2D" uid="uid://bgd2a5j0oct3h" path="res://scenes/game_object/player/player.png" id="4_vu0lo"]
+[ext_resource type="PackedScene" uid="uid://bhsmngj7x2aco" path="res://scenes/components/orbit_box/orbit_box.tscn" id="5_uhw33"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_g7470"]
 radius = 12.0
@@ -15,3 +18,14 @@ shape = SubResource("CircleShape2D_g7470")
 [node name="Sprite2D" type="Sprite2D" parent="."]
 scale = Vector2(1.25, 1.25)
 texture = ExtResource("1_fx2rj")
+
+[node name="RotateAnchor" type="Node2D" parent="."]
+script = ExtResource("3_0vatv")
+
+[node name="SnapPoint" type="Node2D" parent="RotateAnchor"]
+
+[node name="Sprite2D" type="Sprite2D" parent="RotateAnchor/SnapPoint"]
+scale = Vector2(0.01, 0.01)
+texture = ExtResource("4_vu0lo")
+
+[node name="OrbitBox" parent="." instance=ExtResource("5_uhw33")]

--- a/new year jam/scenes/main/main.tscn
+++ b/new year jam/scenes/main/main.tscn
@@ -4,8 +4,8 @@
 [ext_resource type="PackedScene" uid="uid://dk0xl3if1c4ne" path="res://scenes/ui/stamina_bar.tscn" id="1_k22fg"]
 [ext_resource type="Texture2D" uid="uid://bmqipqpbnj7go" path="res://assets/colour_palette.png" id="2_r0h23"]
 [ext_resource type="PackedScene" uid="uid://bxpvjoirm48mm" path="res://scenes/manager/star_manager/star_manager.tscn" id="3_rhy5l"]
+[ext_resource type="PackedScene" uid="uid://j21yomhehfx0" path="res://scenes/manager/orbit_manager/orbit_manager.tscn" id="4_dkndy"]
 [ext_resource type="PackedScene" uid="uid://bp3l8aovtvlcw" path="res://scenes/game_object/player/player.tscn" id="4_wlri3"]
-[ext_resource type="PackedScene" uid="uid://j21yomhehfx0" path="res://scenes/manager/orbit_manager/orbit_manager.tscn" id="5_fckb1"]
 [ext_resource type="PackedScene" uid="uid://chaqq3ne7ph04" path="res://scenes/manager/stamina_manager/stamina_manager.tscn" id="6_yo2y2"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_63evu"]
@@ -146,21 +146,23 @@ layer_1/name = "star_spawn_location"
 layer_1/enabled = false
 layer_1/tile_data = PackedInt32Array(2162692, 2359297, 0, 1048581, 2359297, 0, 1048587, 2359297, 0, 589838, 2359297, 0, 393231, 2359297, 0, 917519, 2359297, 0, 1900564, 2359297, 0, 2031639, 2359297, 0, 2293785, 2359297, 0, 1638426, 2359297, 0, 1900572, 2359297, 0, 524318, 2359297, 0, 2424870, 2359297, 0, 1638405, 2359297, 1, 1441804, 2359297, 1, 2293775, 2359297, 1, 1835017, 2359297, 1, 1114139, 2359297, 1, 1376290, 2359297, 1, 1310758, 2359297, 1, 1769507, 2359297, 1, 589858, 2359297, 1, 327718, 2359297, 1, 458778, 2359297, 1, 655367, 2359297, 1, 1114133, 2359297, 1, 786458, 2359297, 1, 2097185, 2424833, 1, 1376274, 2424833, 1, 196628, 2424833, 1, 2031631, 2424833, 1, 1048610, 2424833, 1, 327688, 2424833, 1, 196618, 2424833, 1, 1048617, 2359297, 1, 720938, 2359297, 1, 1769514, 2359297, 0, 2162732, 2424833, 1, 1507373, 2359297, 1, 1245231, 2424833, 1, 2359343, 2424833, 1, 589873, 2359297, 1, 327730, 2359297, 1, 1638450, 2424833, 1, 2031666, 2359297, 1, 1048629, 2359297, 0, 1572919, 2359297, 0, 2424888, 2359297, 0, 589882, 2359297, 1, 1048634, 2424833, 1, 1966138, 2424833, 1, 2359355, 2359297, 0, 327740, 2424833, 1, 1507388, 2359297, 0, 786495, 2359297, 1, 1179711, 2359297, 1, 524352, 2424833, 1, 1114178, 2359297, 1, 1769538, 2359297, 0, 393283, 2424833, 1)
 
-[node name="Player" parent="TileMap" instance=ExtResource("4_wlri3")]
-position = Vector2(81, 271)
+[node name="StarManager" parent="." node_paths=PackedStringArray("tilemap") instance=ExtResource("3_rhy5l")]
+tilemap = NodePath("../TileMap")
 
-[node name="FollowCam" type="Camera2D" parent="TileMap/Player" node_paths=PackedStringArray("tilemap")]
+[node name="OrbitManager" parent="." node_paths=PackedStringArray("player") instance=ExtResource("4_dkndy")]
+player = NodePath("../Player")
+
+[node name="StaminaManager" parent="." instance=ExtResource("6_yo2y2")]
+
+[node name="Player" parent="." node_paths=PackedStringArray("orbit_manager") instance=ExtResource("4_wlri3")]
+position = Vector2(81, 271)
+orbit_manager = NodePath("../OrbitManager")
+
+[node name="FollowCam" type="Camera2D" parent="Player" node_paths=PackedStringArray("tilemap")]
 limit_left = 0
 limit_top = 0
 limit_right = 480
 limit_bottom = 288
 position_smoothing_enabled = true
 script = SubResource("GDScript_pdf6v")
-tilemap = NodePath("../..")
-
-[node name="StaminaManager" parent="." instance=ExtResource("6_yo2y2")]
-
-[node name="StarManager" parent="." node_paths=PackedStringArray("tilemap") instance=ExtResource("3_rhy5l")]
-tilemap = NodePath("../TileMap")
-
-[node name="OrbitManager" parent="." instance=ExtResource("5_fckb1")]
+tilemap = NodePath("../../TileMap")

--- a/new year jam/scenes/main/main.tscn
+++ b/new year jam/scenes/main/main.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=12 format=3 uid="uid://cpmedye8vw1kg"]
+[gd_scene load_steps=13 format=3 uid="uid://cpmedye8vw1kg"]
 
 [ext_resource type="Texture2D" uid="uid://bic86xsl4pp0t" path="res://assets/placeholder_tilemap.png" id="1_2a3hw"]
 [ext_resource type="PackedScene" uid="uid://dk0xl3if1c4ne" path="res://scenes/ui/stamina_bar.tscn" id="1_k22fg"]
+[ext_resource type="PackedScene" uid="uid://dxnybk67rxr0l" path="res://scenes/ui/exit_prompt.tscn" id="2_ckfdl"]
 [ext_resource type="Texture2D" uid="uid://bmqipqpbnj7go" path="res://assets/colour_palette.png" id="2_r0h23"]
 [ext_resource type="PackedScene" uid="uid://bxpvjoirm48mm" path="res://scenes/manager/star_manager/star_manager.tscn" id="3_rhy5l"]
 [ext_resource type="PackedScene" uid="uid://j21yomhehfx0" path="res://scenes/manager/orbit_manager/orbit_manager.tscn" id="4_dkndy"]
@@ -125,17 +126,15 @@ func _ready():
 	var worldSizeInPixels = mapRect.size * tileSize
 	limit_right = worldSizeInPixels.x
 	limit_bottom = worldSizeInPixels.y
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(_delta):
-	pass
 "
 
 [node name="Main" type="Node2D"]
 
 [node name="StaminaBar" parent="." node_paths=PackedStringArray("stamina_manager") instance=ExtResource("1_k22fg")]
 stamina_manager = NodePath("../StaminaManager")
+
+[node name="ExitPrompt" parent="." node_paths=PackedStringArray("player") instance=ExtResource("2_ckfdl")]
+player = NodePath("../Player")
 
 [node name="TileMap" type="TileMap" parent="."]
 tile_set = SubResource("TileSet_3e1r1")

--- a/new year jam/scenes/manager/orbit_manager/orbit_manager.gd
+++ b/new year jam/scenes/manager/orbit_manager/orbit_manager.gd
@@ -12,16 +12,6 @@ const ORBIT_FOLLOW_ACCEL = 50
 signal orbit_exited
 # my wish is for this to control player orbit movement
 
-func get_projected_position(vec : Vector2):
-	var x = vec.x
-	var y = vec.y
-	var angle = star_to_orbit.rotate_anchor.rotation
-	# r = A * cos omega i + A sin omega t
-	var a = x * cos(angle) - y * sin(angle)
-	var b = y * cos(angle) - x * sin(angle)
-	
-	return Vector2(a, b)
-
 func _ready():
 	stars = get_tree().get_nodes_in_group("stars")
 	player.entered_star_orbit.connect(on_player_enter_orbit)

--- a/new year jam/scenes/manager/orbit_manager/orbit_manager.gd
+++ b/new year jam/scenes/manager/orbit_manager/orbit_manager.gd
@@ -1,32 +1,54 @@
 extends Node
+class_name OrbitManager
 
-const ORBIT_BOX = preload("res://scenes/components/orbit_box/orbit_box.tscn")
-@export var collision_shapes : Array[PackedScene]
+@export var player : Player
 var stars
+var star_to_orbit : Star
+var move_player : bool = false
+#var move_player_into_orbit : bool = false
+
+const ORBIT_FOLLOW_ACCEL = 50
+
+signal orbit_exited
+# my wish is for this to control player orbit movement
+
+func get_projected_position(vec : Vector2):
+	var x = vec.x
+	var y = vec.y
+	var angle = star_to_orbit.rotate_anchor.rotation
+	# r = A * cos omega i + A sin omega t
+	var a = x * cos(angle) - y * sin(angle)
+	var b = y * cos(angle) - x * sin(angle)
+	
+	return Vector2(a, b)
 
 func _ready():
-	assign_orbits_to_stars()
-
-func assign_orbits_to_stars():
 	stars = get_tree().get_nodes_in_group("stars")
+	player.entered_star_orbit.connect(on_player_enter_orbit)
+	player.exiting_star_orbit.connect(on_player_request_orbit_exit)
 
-	for star in stars:
-		var orbit = ORBIT_BOX.instantiate()
-		var star_shape = star.orbit_size
-		star.add_child(orbit)
-		
-		var col
-		
-		match star_shape:
-			"Small":
-				col = collision_shapes[0].instantiate()
-				orbit.add_child(col)
-			"Medium":
-				col = collision_shapes[1].instantiate()
-				orbit.add_child(col)
-			"Large":
-				col = collision_shapes[2].instantiate()
-				orbit.add_child(col)
-		
-		
-		
+func _physics_process(delta):
+	if move_player:
+		move_player_around_orbit(delta)
+
+func on_player_enter_orbit(orbiting_star):
+	star_to_orbit = orbiting_star
+	#var tween = get_tree().create_tween()
+	#tween.set_ease(Tween.EASE_OUT)
+	#tween.tween_property(player, "velocity", Vector2.ZERO, 0.5)
+	#tween.parallel().tween_property(player, "global_position", orbiting_star.orbit_point.global_position, 0.5)
+	#await tween.finished
+	move_player = true
+
+func move_player_around_orbit(delta):
+	player.global_position = player.global_position.move_toward(star_to_orbit.orbit_point.global_position, ORBIT_FOLLOW_ACCEL * delta)
+
+func on_player_request_orbit_exit():
+	move_player = false
+	var direction = star_to_orbit.global_position.direction_to(player.global_position)
+	var dir = star_to_orbit.orbit_point.global_position.direction_to(player.global_position)
+	var target_position : Vector2 = player.global_position + dir *30
+	
+	player.velocity = direction*100 # a little impulse for a smooth transition
+	await get_tree().create_timer(0.5).timeout # hard coded for safetyd
+	orbit_exited.emit()

--- a/new year jam/scenes/manager/orbit_manager/orbit_manager.tscn
+++ b/new year jam/scenes/manager/orbit_manager/orbit_manager.tscn
@@ -1,10 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://j21yomhehfx0"]
+[gd_scene load_steps=2 format=3 uid="uid://j21yomhehfx0"]
 
 [ext_resource type="Script" path="res://scenes/manager/orbit_manager/orbit_manager.gd" id="1_eigfw"]
-[ext_resource type="PackedScene" uid="uid://cdg65i7wqtvul" path="res://scenes/game_object/star/resources/collision_small.tscn" id="2_yxkg5"]
-[ext_resource type="PackedScene" uid="uid://cbswhjtnythkk" path="res://scenes/game_object/star/resources/collision_medium.tscn" id="3_ob7kh"]
-[ext_resource type="PackedScene" uid="uid://bc6vb0utaxlxi" path="res://scenes/game_object/star/resources/collision_large.tscn" id="4_beanp"]
 
 [node name="OrbitManager" type="Node"]
 script = ExtResource("1_eigfw")
-collision_shapes = Array[PackedScene]([ExtResource("2_yxkg5"), ExtResource("3_ob7kh"), ExtResource("4_beanp")])

--- a/new year jam/scenes/manager/stamina_manager/stamina_manager.gd
+++ b/new year jam/scenes/manager/stamina_manager/stamina_manager.gd
@@ -14,13 +14,13 @@ func _ready():
 func increment_stamina(number: float):
 	current_stamina += number
 	stamina_updated.emit(current_stamina)
-	print(current_stamina)
+	#print(current_stamina)
 	
 
 func decrement_stamina(number:float):
 	current_stamina -= number
 	stamina_updated.emit(current_stamina)
-	print(current_stamina)
+	#print(current_stamina)
 
 
 func on_player_move(stamina_drain: float):

--- a/new year jam/scenes/manager/star_manager/star_manager.gd
+++ b/new year jam/scenes/manager/star_manager/star_manager.gd
@@ -6,7 +6,7 @@ extends Node2D
 @export var tilemap: TileMap
 
 var min_stars = 10
-var max_stars = 20
+var max_stars = 10
 
 func _ready():
 	var spawn_locations = tilemap.get_used_cells_by_id(1)

--- a/new year jam/scenes/ui/exit_prompt.gd
+++ b/new year jam/scenes/ui/exit_prompt.gd
@@ -1,0 +1,19 @@
+extends CanvasLayer
+
+@export var player : Player
+@onready var animation_player = $AnimationPlayer
+@onready var label = $MarginContainer/Label
+
+
+var op : bool = false
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	label.modulate.a = 0
+	player.timer_value.connect(change_opacity)
+
+
+func change_opacity():
+	animation_player.play("fade_out")
+	await animation_player.animation_finished
+	animation_player.play_backwards("fade_out")

--- a/new year jam/scenes/ui/exit_prompt.tscn
+++ b/new year jam/scenes/ui/exit_prompt.tscn
@@ -1,0 +1,66 @@
+[gd_scene load_steps=6 format=3 uid="uid://dxnybk67rxr0l"]
+
+[ext_resource type="FontFile" uid="uid://dn5vvdt0pfq1m" path="res://assets/dialogues/dialogue_balloons/font_file_dialogue.tres" id="1_l4h6d"]
+[ext_resource type="Script" path="res://scenes/ui/exit_prompt.gd" id="1_leypy"]
+
+[sub_resource type="Animation" id="Animation_cx7hl"]
+resource_name = "fade_out"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("MarginContainer/Label:modulate")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 0.5),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_kqxdl"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("MarginContainer/Label:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_o7qyl"]
+_data = {
+"RESET": SubResource("Animation_kqxdl"),
+"fade_out": SubResource("Animation_cx7hl")
+}
+
+[node name="ExitPrompt" type="CanvasLayer"]
+script = ExtResource("1_leypy")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_bottom = 100
+
+[node name="Label" type="Label" parent="MarginContainer"]
+texture_filter = 1
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 8
+theme_override_fonts/font = ExtResource("1_l4h6d")
+theme_override_font_sizes/font_size = 24
+text = "Exiting orbit..."
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_o7qyl")
+}
+speed_scale = 2.0


### PR DESCRIPTION
there's some mess but it should be done. feel free to clean up later

- adds rotating orbits
- adds signals to player and stars
   - player: player entered orbit, player exited orbit, signal value (ignore - badly named because of hastily done UI signal)
   - stars: orbit entered
- repurposed orbit_manager to handle player position during orbits
- refactored stars to be in control of spawning their own orbits instead of manager
- ui for exiting orbits

for whoever's gonna make the path visualization at the end, make sure to add a check for duplicate coordinates